### PR TITLE
로그인페이지, 마이페이지, 주문상세페이지, 과별페이지_기능 구현 완료

### DIFF
--- a/src/components/DepartmentHeader/DepartmentHeader.jsx
+++ b/src/components/DepartmentHeader/DepartmentHeader.jsx
@@ -12,6 +12,7 @@ import {
 } from "./DepartmentHeaderStyle";
 import { useNavigate } from "react-router-dom";
 import SearchOverlay from "../search/SearchOverlay"; // Adjust the path as necessary
+import { useAuth } from '../../contexts/AuthContext';
 
 const mockArtworks = [
   {
@@ -62,7 +63,8 @@ const mockArtworks = [
 export const DepartmentHeader = () => {
   const navigate = useNavigate();
   const [isSearchVisible, setIsSearchVisible] = useState(false);
-
+  const { user, logout } = useAuth();
+  
   // 뒤로가기 버튼을 눌렀을 때
   const handleBack = () => {
     if (window.location.pathname.startsWith("/dept_detail")) {
@@ -89,12 +91,21 @@ export const DepartmentHeader = () => {
 
   //장바구니 버튼 눌렀을때
   const handleCart = () => {
-    navigate("/cart");
+    if (user) {
+      navigate("/cart");
+    } else {
+      navigate("/signin");
+    }
   };
 
   //마이페이지 버튼 눌렀을때
   const handleMypage = () => {
-    navigate("/my");
+    if (user) {
+      navigate("/my");
+    } else {
+      navigate("/signin");
+    }
+    
   };
 
   return (

--- a/src/components/DepartmentHeader/DepartmentHeaderStyle.js
+++ b/src/components/DepartmentHeader/DepartmentHeaderStyle.js
@@ -34,6 +34,7 @@ export const TextWrapper = styled.span`
 
 export const BackBtn = styled.div`
   padding: 10px;
+  cursor: pointer;
   @media (max-width: 768px) {
     padding: 5px;
     margin-top: 5px;
@@ -66,6 +67,7 @@ export const Ellipse = styled.div`
   left: 0;
   top: 0;
   width: 25px;
+  cursor: pointer;
 `;
 
 export const Ellipse2 = styled.div`
@@ -77,6 +79,7 @@ export const Ellipse2 = styled.div`
   height: 25px;
   top: 0;
   width: 25px;
+  cursor: pointer;
 `;
 
 export const Ellipse3 = styled.div`
@@ -88,4 +91,5 @@ export const Ellipse3 = styled.div`
   height: 25px;
   top: 0;
   width: 25px;
+  cursor: pointer;
 `;

--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -17,6 +17,8 @@ import My from "../pages/My/My.jsx";
 import Cart from "../pages/Cart/Cart.jsx";
 import SearchPage from "../pages/Serach";
 
+import GoogleCallback from '../pages/SignIn/ GoogleCallback.jsx';
+
 
 function Router() {
   return (
@@ -37,6 +39,7 @@ function Router() {
         <Route path="/my" element={<My />} />
         <Route exact path="/cart" element={<Cart />}></Route>
         <Route exact path="/payment-info" element={<PaymentInfo />}></Route>
+        <Route path="/auth/callback" element={<GoogleCallback />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/Department/Department.json
+++ b/src/pages/Department/Department.json
@@ -8,15 +8,15 @@
     "Instagram": "https://www.instagram.com/snufa2023/",
     "collection": "https://art.snu.ac.kr/artexhibition/?cate%5B0%5D=20211&amp;cate%5B1%5D=painting&amp;cate%5B2%5D=&amp;cate%5B3%5D=&amp;cate%5B4%5D=",
     "homepage": "https://art.snu.ac.kr/category/painting/",
-    "departmentDescription": "서양화과에는 창의적이고 전문성을 갖춘 미술가의 육성을 목표로 4년 과정의 미술학 학사 과정과 각각 2년 과정의 석, 박사 과정이 개설되어 있습니다. 대학 1학년 기초과정에서는 조형 및 표현 능력의 함양을 위해 다양한 매체와 조형방식을 활용하는 통합적인 실습 및 이론 교육이 이루어집니다. 2, 3 ,4학년 과정에서는 전공과 각 학년에 부합하는 학년별 전공 실기 수업을 통해 다양한 표현을 실험하고 자신만의 창작방식을 발전시킬 수 있습니다.특히 3, 4학년 과정에는 전공을 심화하기 위한 전공 스튜디오 수업이 개설되어 있습니다. 아울러 시각예술 전반에 대한 지식과 미술사를 체계적으로 습득하여 실기와 이론을 겸비할 수 있도록 미술사 및 이론 수업을 전 학년에 걸쳐수강할 수 있습니다."
+    "departmentDescription": "금속공예전공에서는 금속의 다양한 성형제작기법을 통하여 재료 및 기법을 이해하고, 기초과정에서부터 경험한 조형교육의 내용과 함께 개인적인 상상력을 바탕으로 창의적인 형태를 연구할 수 있도록 실기 및 이론 과목들을 구성한다."
   },  {
     "Department": "Ceramic",
     "titleColor": "#FF983B",
     "imgPath": "landing-oriental.webp",
-    "departmentName": "서울대학교 도예전공",
+    "departmentName": "서울대학교 도자공예전공",
     "Instagram": "https://www.instagram.com/snu.orientalpainting_official/",
     "collection": "https://art.snu.ac.kr/artexhibition/?cate%5B0%5D=20211&cate%5B1%5D=oriental-painting&cate%5B2%5D=&cate%5B3%5D=&cate%5B4%5D=",
     "homepage": "https://art.snu.ac.kr/category/oriental-painting/",
-    "departmentDescription": "동양화과에는 4년 과정의 미술 학사와 2년 과정의 석,박사 과정이 설치되어 있습니다. 오랜 역사를 지닌 전통 조형론을 바탕으로, 전통미술의 계승과 동양화의 현대적 모색이 함께 이루어지고 있습니다. 학부 1학년 기초과정에서는 한국 및 동-서양미술의 상호 연계성을 종합적으로 체험하며 폭넓은 표현 능력과 교양을 쌓습니다. 이후 2, 3, 4학년 전공과정에서는 동양적 미의식에 입각한 표현 방법을 연구하며, 조형 이론을 통해 개인의 창작 능력을 배양하는 데 중점을 두고 있습니다. 대학원의 석,박사 과정에서는 전통적 회화 기법과 조형 이론에 대한 이해를 심화시키는 동시에 현대회화의 다양한 표현 방법과 매체들을 응용하여 개성적인 표현을 실험하고 있습니다. 또한 작품 전시 기획론, 감정론, 작품 비평론 및 현장 수업을 통해 작품에 대한 안목, 논리적인 분석, 교육 방법의 연구 등 미술 전문가로서의 소양을 키우게 됩니다. 창작과 이론이 밀접하게 연관되는 과정을 통해 지적 사고와 표현 영역을 확장시켜나갈 수 있습니다."
+    "departmentDescription": "도자의 전통과 현대, 예술과 과학, 기술과 인문을 접목하는 새롭고 체계적인 수업 내용을 통해 기초실기 능력을 배양하고 시대적이며 창의적인 자질개발을 목표로 하는 수업내용을 편성한다."
   }
 ]

--- a/src/pages/DeptDetail/components/dept_header/DeptDetailHeader.jsx
+++ b/src/pages/DeptDetail/components/dept_header/DeptDetailHeader.jsx
@@ -54,7 +54,6 @@ function DeptDetailHeaderComponent() {
               //동그라미 click 시, 해당 과 페이지로 이동
               onClick={() => {
                 navigate(`/dept_detail/${dept.Department}`);
-                
               }} 
             ></DeptDetailHeadercircle>
             <DeptDetailHeadernavinfowrapper isNavHover={isNavHover[i]}>

--- a/src/pages/DeptDetail/components/dept_header/DeptDetailHeaderStyles.js
+++ b/src/pages/DeptDetail/components/dept_header/DeptDetailHeaderStyles.js
@@ -82,6 +82,7 @@ export const DeptDetailHeadercircle = styled.div({
   flexShrink: 0,
   background: "rgba(217, 217, 217, 0.30)",
   borderRadius: "50%",
+  cursor: "pointer",
   ":hover": {
     background: "#A348F6",
   },

--- a/src/pages/DeptDetail/components/dept_info/DeptDetailDeptInfoComponentStyles.js
+++ b/src/pages/DeptDetail/components/dept_info/DeptDetailDeptInfoComponentStyles.js
@@ -34,6 +34,7 @@ export const DeptInfoImgPassive = styled.div({
     height: 10,
     borderRadius: "10px",
   },
+  cursor: "pointer",
 });
 
 export const DeptInfoImgActive = styled.img({

--- a/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
+++ b/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
@@ -181,7 +181,7 @@ function ExhibitionGrid({items, setItems, curDepartmentObj}) {
             <ArtWorkInfoWrap>
               <ArtWorkTitle>{artWork.title}</ArtWorkTitle>
               <ArtWorkSubTitle>
-                {artWork.artist} | {artWork.tool} | {artWork.size}
+                {artWork.name} | {artWork.material} | {artWork.size}
               </ArtWorkSubTitle>
             </ArtWorkInfoWrap>
           </ArtWorkWrap>

--- a/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
+++ b/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
@@ -20,7 +20,7 @@ import {
   TitleText,
   TitleYear,
 } from "./DeptDetailExhibitionComponentStyles";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { curDepartmentObjContext } from "../../DeptDetail";
 import api from "../../../../utils/axios";
 import ErrorMessage from "../../../../components/common/ErrorMessage";
@@ -28,8 +28,13 @@ import Loading from "../../../../components/common/Loading";
 
 function ExhibitionTitle({items, setItems, curDepartmentObj}) {
   const [searchTerm, setSearchTerm] = useState(""); // 검색어 상태
-  //const [searchResults, setSearchResults] = useState([]); // 검색 결과 상태
+  const location = useLocation(); // 현재 경로 가져오기
 
+  // 경로 변경 시 검색창 초기화
+  useEffect(() => {
+    setSearchTerm(""); // 검색어 상태 초기화
+  }, [location]);
+  
   // 검색 API 호출 함수
   const search = async (term) => {
     try {
@@ -75,7 +80,6 @@ function ExhibitionGrid({items, setItems, curDepartmentObj}) {
 
   // 현재 페이지
   const [currentPage, setCurrentPage] = useState(1);
-  //const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
@@ -128,7 +132,7 @@ function ExhibitionGrid({items, setItems, curDepartmentObj}) {
 
   useEffect(() => {
     // 이미지 높이 (너비와 동일, 즉 셀의 너비와 같음) + 각 요소 사이의 gap 높이 * 2
-    if (imgRef.current) {
+    if (imgRef.current && items.length > 0) {
       const columnHeight = imgRef.current.clientWidth;
       const computedMinHeight = columnHeight * 2; // 2행 + gap
       setMinHeight(computedMinHeight);
@@ -161,10 +165,10 @@ function ExhibitionGrid({items, setItems, curDepartmentObj}) {
             <ArtWorkCircle
               style={{
                 display: isHover[i] ? "block" : "none",
-                width: imgRef.current.clientWidth
+                width: imgRef.current?.clientWidth
                   ? imgRef.current.clientWidth * 1.4
                   : 0,
-                height: imgRef.current.clientWidth
+                height: imgRef.current?.clientWidth
                   ? imgRef.current.clientWidth * 1.4
                   : 0,
               }}
@@ -201,7 +205,6 @@ function ExhibitionGrid({items, setItems, curDepartmentObj}) {
 
 function DeptDetailExhibitionComponent({items, setItems}) {
   const curDepartmentObj = useContext(curDepartmentObjContext);
-  console.log(curDepartmentObj)
 
   return (
     <DeptDetailExhibition>

--- a/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
+++ b/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
@@ -26,8 +26,7 @@ import api from "../../../../utils/axios";
 import ErrorMessage from "../../../../components/common/ErrorMessage";
 import Loading from "../../../../components/common/Loading";
 
-function ExhibitionTitle({items, setItems}) {
-  const curDepartmentObj = useContext(curDepartmentObjContext);
+function ExhibitionTitle({items, setItems, curDepartmentObj}) {
   const [searchTerm, setSearchTerm] = useState(""); // 검색어 상태
   //const [searchResults, setSearchResults] = useState([]); // 검색 결과 상태
 
@@ -70,7 +69,7 @@ function ExhibitionTitle({items, setItems}) {
   );
 }
 
-function ExhibitionGrid({items, setItems}) {
+function ExhibitionGrid({items, setItems, curDepartmentObj}) {
   // 한 페이지에서 보일 작품 수
   const itemsPerPage = 8;
 
@@ -80,7 +79,6 @@ function ExhibitionGrid({items, setItems}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
-  const curDepartmentObj = useContext(curDepartmentObjContext);
 
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
@@ -202,10 +200,13 @@ function ExhibitionGrid({items, setItems}) {
 }
 
 function DeptDetailExhibitionComponent({items, setItems}) {
+  const curDepartmentObj = useContext(curDepartmentObjContext);
+  console.log(curDepartmentObj)
+
   return (
     <DeptDetailExhibition>
-      <ExhibitionTitle items={items} setItems={setItems}/>
-      <ExhibitionGrid items={items} setItems={setItems}/>
+      <ExhibitionTitle items={items} setItems={setItems} curDepartmentObj={curDepartmentObj}/>
+      <ExhibitionGrid items={items} setItems={setItems} curDepartmentObj={curDepartmentObj}/>
     </DeptDetailExhibition>
   );
 }

--- a/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
+++ b/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
@@ -34,7 +34,7 @@ function ExhibitionTitle({items, setItems, curDepartmentObj}) {
   useEffect(() => {
     setSearchTerm(""); // 검색어 상태 초기화
   }, [location]);
-  
+
   // 검색 API 호출 함수
   const search = async (term) => {
     try {

--- a/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponentStyles.js
+++ b/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponentStyles.js
@@ -167,6 +167,7 @@ export const ArtWorkImg = styled.img({
   aspectRatio: "1", // 너비와 높이를 동일하게 설정
   borderRadius: "20px",
   backdropFilter: "blur(50px)",
+  cursor: "pointer",
   "@media (max-width: 768px)": {
     borderRadius: "10px",
   },

--- a/src/pages/Landing/DeptSection.jsx
+++ b/src/pages/Landing/DeptSection.jsx
@@ -13,7 +13,7 @@ import ErrorMessage from "../../components/common/ErrorMessage";
 import api from "../../utils/axios";
 
 const departments = [
-  { title: "Ceramic", subtitle: "도예전공" },
+  { title: "Ceramic", subtitle: "도자공예전공" },
   { title: "Metal", subtitle: "금속공예전공" },
 ];
 

--- a/src/pages/My/My.jsx
+++ b/src/pages/My/My.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useAuth } from '../../contexts/AuthContext';
 import { useMediaQuery } from "react-responsive";
 import {
   Wrap,
@@ -25,18 +26,27 @@ import {
   PurpleText,
   Bottom,
   MobileWrapper,
-
+  SignOutButton,
 } from "./MyStyle";
 import { DepartmentHeader } from "../../components/DepartmentHeader/DepartmentHeader";
 import {useNavigate} from "react-router-dom";
 
 function My() {
+  const { user, logout } = useAuth();
   const isMobile = useMediaQuery({ maxWidth: 768 });
-
   const navigate = useNavigate();
   const handlePaymentInfo = () => {
     navigate("/PaymentInfo")
   }
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      navigate("/");
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+    }
+  };
 
   return (
     <Wrap>
@@ -111,6 +121,7 @@ function My() {
           </RectangleImage>
         </MainFrame>
       </Frame>
+      <SignOutButton onClick={handleLogout}>로그아웃</SignOutButton>
     </Wrap>
   );
 }

--- a/src/pages/My/My.jsx
+++ b/src/pages/My/My.jsx
@@ -90,8 +90,8 @@ function My() {
   };
 
   //주문 상세 페이지로 이동
-  const handlePaymentInfo = () => {
-    navigate("/PaymentInfo")
+  const handlePaymentInfo = (itemId) => {
+    navigate("/payment-info", { state: { itemId } });
   }
 
   // 로그아웃 핸들러
@@ -145,7 +145,7 @@ function My() {
                         </Right>
                       </Product1>
                       <Bottom>
-                        <RefundButton onClick={handlePaymentInfo}>결제 정보</RefundButton>
+                        <RefundButton onClick={() => handlePaymentInfo(item.item_id)}>결제 정보</RefundButton>
                         <DeliveryTrackingButton onClick={() => handleDeliveryCheck(item.item_id)}>
                           배송 조회
                         </DeliveryTrackingButton>
@@ -181,6 +181,7 @@ function My() {
                           {item.price.toLocaleString()}
                           <WhiteText>원</WhiteText>
                         </ProductPrice>
+                        <RefundButton onClick={() => handlePaymentInfo(item.item_id)}>결제 정보</RefundButton>
                         <DeliveryTrackingButton onClick={() => handleDeliveryCheck(item.item_id)}>
                           배송 조회
                         </DeliveryTrackingButton>

--- a/src/pages/My/MyStyle.js
+++ b/src/pages/My/MyStyle.js
@@ -210,6 +210,7 @@ export const DeliveryTrackingButton = styled.div`
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 15px */
+  cursor: pointer;
 
   @media (max-width: 768px) and (min-width: 320px) {
     padding: 10px 23px;
@@ -233,6 +234,7 @@ export const RefundButton = styled.div`
   font-style: normal;
   font-weight: 700;
   line-height: 100%; /* 15px */
+  cursor: pointer;
 
   @media (max-width: 768px) and (min-width: 320px) {
     padding: 8px 13px;
@@ -296,6 +298,7 @@ export const SignOutButton = styled.div`
   font-style: normal;
   font-weight: 400;
   line-height: 100%; /* 24px */
+  cursor: pointer;
 
   position: absolute;
   bottom: 20px;  /* 화면 하단에서 20px 위로 띄우기 */

--- a/src/pages/My/MyStyle.js
+++ b/src/pages/My/MyStyle.js
@@ -278,3 +278,27 @@ export const MobileWrapper = styled.div`
   display: flex;
   flex-direction: column;
 `
+
+export const SignOutButton = styled.div`
+  display: flex;
+  width: 205px;
+  height: 56px;
+  padding: 14px 34px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  border-radius: 20px;
+  background: #A348F6;
+  color: #FFF;
+  font-family: Inter;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 24px */
+
+  position: absolute;
+  bottom: 20px;  /* 화면 하단에서 20px 위로 띄우기 */
+  left: 50%;
+  transform: translateX(-50%);  /* 버튼을 수평 중앙에 배치 */
+`

--- a/src/pages/PaymentInfo/PaymentInfo.jsx
+++ b/src/pages/PaymentInfo/PaymentInfo.jsx
@@ -1,5 +1,7 @@
 import React, {useEffect, useState} from "react";
+import { useLocation } from "react-router-dom";
 import {DepartmentHeader} from "../../components/DepartmentHeader/DepartmentHeader";
+import Loading from "../../components/common/Loading";
 import {
     DeliveryAddressWrap,
     MiddleText,
@@ -11,30 +13,35 @@ import {
     TwoTextWrapper,
     MiddleWrapper,
     Wrap,
-    RectangleImage,
-    OrderInformation,
-    OrderDescription,
-    OrderInfoWrapper,
-    LabelValueWrapper,
-    PurpleText, ValueWrapper, AmountValue, Currency, ApprovalTimeText
+    OneTextWrapper,
 } from "./PaymentInfoStyle";
-import paymentData from './PaymentInfo.json'
+//import paymentData from './PaymentInfo.json'
+import api from "../../utils/axios";
+
 
 export const PaymentInfo = () => {
-    const [formData, setFormData] = useState({
-        orderName: "",
-        orderPhone: "",
-        orderEmail: "",
-        addressName: "",
-        addressPhone: "",
-        address: "",
-        detailAddress: "",
-    });
+    const [orderInfo, setOrderInfo] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const location = useLocation();
+    const { itemId } = location.state || {};
 
     useEffect(() => {
-        // Set formData to paymentData only on the initial render
-        setFormData(paymentData);
-    }, []);
+        const fetchOrderInfo = async () => {
+        try {
+            const response = await api.get(`/purchases/${itemId}/`);
+            setOrderInfo(response.data);
+        } catch (err) {
+            setError(err.response?.data?.error || '주문 상세 정보를 불러오는데 실패했습니다.');
+        } finally {
+            setLoading(false);
+        }
+        };
+
+        fetchOrderInfo();
+    }, [itemId]);
+
+    if (loading) return <Loading />;
 
     return (
         <Wrap>
@@ -50,25 +57,25 @@ export const PaymentInfo = () => {
                                 width={30}
                                 placeholder="이름이 없습니다"
                                 name="orderName"
-                                value={formData.orderName}
+                                value={orderInfo.name}
                                 readOnly
                             />
                             <TextWrapper
                                 width={50}
                                 placeholder="전화번호가 없습니다"
                                 name="orderPhone"
-                                value={formData.orderPhone}
+                                value={orderInfo.phone_num}
                                 readOnly
                             />
                         </TwoTextWrapper>
-                        <TextWrapper
+                        <OneTextWrapper
                             width={100}
                             placeholder="이메일 주소가 없습니다"
                             name="orderEmail"
-                            value={formData.orderEmail}
+                            value={orderInfo.email}
                             readOnly
                         />
-                    </OrdererWrap>
+                        </OrdererWrap>
                     <DeliveryAddressWrap>
                         <MiddleText>배송지 정보</MiddleText>
                         <TwoTextWrapper>
@@ -76,29 +83,29 @@ export const PaymentInfo = () => {
                                 width={30}
                                 placeholder="이름이 없습니다"
                                 name="addressName"
-                                value={formData.addressName}
+                                value={orderInfo.name}
                                 readOnly
                             />
                             <TextWrapper
                                 width={50}
                                 placeholder="전화번호가 없습니다"
                                 name="addressPhone"
-                                value={formData.addressPhone}
+                                value={orderInfo.phone_num}
                                 readOnly
                             />
                         </TwoTextWrapper>
-                        <TextWrapper
+                        <OneTextWrapper
                             width={100}
                             placeholder="지번/도로명 주소가 없습니다"
                             name="address"
-                            value={formData.address}
+                            value={orderInfo.address}
                             readOnly
                         />
-                        <TextWrapper
+                        <OneTextWrapper
                             width={100}
                             placeholder="상세 주소가 없습니다"
                             name="detailAddress"
-                            value={formData.detailAddress}
+                            value={orderInfo.address}
                             readOnly
                         />
                     </DeliveryAddressWrap>

--- a/src/pages/PaymentInfo/PaymentInfoStyle.js
+++ b/src/pages/PaymentInfo/PaymentInfoStyle.js
@@ -12,6 +12,7 @@ export const Wrap = styled("div")`
   box-sizing: border-box;
   overflow-y: auto;
   align-items: center;
+  padding: 80px 0 0; 
 `;
 
 export const PaymentText = styled.div`
@@ -108,13 +109,43 @@ export const MiddleText = styled.div`
 export const TwoTextWrapper = styled.div`
   display: flex;
   gap: 10px;
+  width: 100%; /* 전체 너비를 부모 컨테이너에 맞추기 */
+  box-sizing: border-box; /* 테두리와 패딩 포함 */
 `;
 
 export const TextWrapper = styled.input`
   display: flex;
   border-radius: 20px;
   background: rgba(215, 215, 215, 0.3);
-  width: ${({ width }) => width}%;
+  //width: ${({ width }) => width}%;
+  width: 100%;
+  padding-left: 15px;
+  align-items: center;
+  color: #d7d7d7;
+  font-size: 13px;
+  font-style: normal;
+  font-family: KoddiUDOnGothic, sans-serif;
+  font-weight: 400;
+  line-height: 100%;
+  margin-bottom: 12px;
+  height: 43px;
+  border: none;
+  outline: none;
+  &::placeholder {
+    color: #d7d7d7;
+  }
+
+  @media (max-width: 768px) and (min-width: 320px) {
+    font-size: 8px;
+    height: 25px;
+    margin-bottom: 8px;
+  }
+`;
+
+export const OneTextWrapper = styled.input`
+  display: flex;
+  border-radius: 20px;
+  background: rgba(215, 215, 215, 0.3);
   padding-left: 15px;
   align-items: center;
   color: #d7d7d7;

--- a/src/pages/SignIn/ GoogleCallback.jsx
+++ b/src/pages/SignIn/ GoogleCallback.jsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import api from '../../utils/axios';
+
+function GoogleCallback() {
+  const navigate = useNavigate();
+  const { setAuthData } = useAuth();
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      try {
+        // Google OAuth 콜백 URL에서 hash 값을 가져온다
+        const hash = window.location.hash.substring(1);
+        if (!hash) {
+          navigate('/signin', { replace: true });
+          return;
+        }
+
+        const params = new URLSearchParams(hash);
+        const tokens = {
+          access_token: params.get('access_token'),
+          expires_at: params.get('expires_at'),
+          expires_in: params.get('expires_in'),
+          provider_token: params.get('provider_token'),
+          refresh_token: params.get('refresh_token'),
+          token_type: params.get('token_type')
+        };
+
+        if (!tokens.access_token || !tokens.refresh_token) {
+          throw new Error('Invalid tokens');
+        }
+
+        // 서버로 전송하여 인증 처리
+        const response = await api.post('/auth/google/callback/', tokens);
+        
+        if (response.status === 200) {
+          const userResponse = await api.get('/auth/user/');
+          await setAuthData(userResponse.data);
+          navigate('/', { replace: true });
+        }
+      } catch (error) {
+        console.error('Google 로그인 처리 중 오류:', error);
+        navigate('/signin', { replace: true });
+      }
+    };
+
+    handleCallback();
+  }, [navigate, setAuthData]);
+
+  return (
+    <p>로그인 처리중...</p>
+  );
+}
+
+export default GoogleCallback;

--- a/src/pages/SignIn/SignIn.jsx
+++ b/src/pages/SignIn/SignIn.jsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useState } from "react";
+//import { useForm } from 'react-hook-form';
+import { useAuth } from '../../contexts/AuthContext';
+//import { useNavigate, Link } from 'react-router-dom';
 import {
   Wrap,
   PageText,
@@ -12,6 +15,8 @@ import {
 import { DepartmentHeader } from "../../components/DepartmentHeader/DepartmentHeader";
 
 function SignIn() {
+  const { googleLogin } = useAuth();
+
   return (
     <Wrap>
       <DepartmentHeader />
@@ -21,7 +26,7 @@ function SignIn() {
             <PageText>로그인</PageText>
           </TextFrame>
           <Line />
-          <ImageFrame src="/google-signin-icon.png" />
+          <ImageFrame src="/google-signin-icon.png" onClick={googleLogin}/>
         </MainFrame>
       </MainWrapper>
       <BackgroundCircle />

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -60,10 +60,10 @@ api.interceptors.response.use(
         // 토큰 갱신 실패 시 로그인 페이지로 이동 (단, 로그인 페이지와 작품 상세 페이지는 제외)
         processQueue(refreshError);
         if (
-          window.location.pathname !== "/login" &&
+          window.location.pathname !== "/signin" &&
           !window.location.pathname.startsWith("/items")
         ) {
-          window.location.href = "/login";
+          //window.location.href = "/signin";
         }
         return Promise.reject(refreshError);
       } finally {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[0] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
SignInPage -> main

### 변경 사항
로그인페이지, 마이페이지, 주문상세페이지, 과별페이지의 기능을 구현함.
(마이페이지, 주문상세페이지 모두 로그인을 필요로 하여, 
따로 브랜치를 파지 않고 모두 SignInPage에서 작업함.)

### 테스트 결과
https://github.com/user-attachments/assets/2e96e1a0-9cbb-42e7-ba52-9303b020aa3f
(과별페이지 작품들의 작가이름은 잘 불러오도록 코드 수정했고, 재료, 사이즈는 샘플 DB에 아직 없어서 불러오기가 안 되는 상태임.)
