### PR TITLE
fix: 로그인 및 로그아웃 코드 수정

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -51,8 +51,20 @@ export function AuthProvider({ children }) {
 
     const logout = async () => {
         try {
+            // refresh token을 쿠키에서 가져옴
+            const refreshToken = document.cookie
+                .split('; ')
+                .find(row => row.startsWith('refresh_token='))
+                ?.split('=')[1];
+
+            if (!refreshToken) {
+                throw new Error('Refresh token not found');
+            }
+
             //백엔드 로그아웃 API 호출
-            await api.get('/auth/logout/');
+            await api.post('/auth/logout/', {
+                refresh_token: refreshToken
+            });
 
             //쿠키 삭제
             document.cookie = "access_token=; Max-Age=0; path=/; secure; SameSite=Lax";
@@ -62,7 +74,7 @@ export function AuthProvider({ children }) {
             setUser(null);
             setIsAuthenticated(false);
         } catch (error) {
-            console.error("로그아웃 실해:", error);
+            console.error("로그아웃 실패:", error);
         }
     };
 

--- a/src/pages/SignIn/ GoogleCallback.jsx
+++ b/src/pages/SignIn/ GoogleCallback.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
 import api from "../../utils/axios";
 import Cookies from "js-cookie";
-import axios from "axios";
 
 function GoogleCallback() {
   const navigate = useNavigate();
@@ -34,8 +33,8 @@ function GoogleCallback() {
         }
 
         // 서버로 전송하여 인증 처리
-        const response = await axios.post(
-          "https://newgraduart-backend.fly.dev/api/v1/auth/google/callback/",
+        const response = await api.post(
+          "/auth/google/callback/",
           tokens
         );
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[o] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
main

### 변경 사항
logout, token refresh 에서는 refresh token을 쿠키에서 빼서 post 요청의 body에 담아서 보냈고요,
기타 일반적인 경우에는 authorization header에 담아서 보냈습니다

그에 맞게 backend의 코드도 수정했고요

### 테스트 결과
일단 로컬에서는 테스트 성공했습니다
