### PR TITLE
[FIX] Mainpage, PaySuccesspage color change

### DIFF
--- a/src/GlobalColors.css
+++ b/src/GlobalColors.css
@@ -1,9 +1,10 @@
 :root {
-  --purple: #4e5a5b; /* 짙은녹색 */
+  --purple: #4e5a5b; /* 짙은녹색, 변수명 바꾸는 리소스 감축을 위해 purple이면 짙은 */
   --black: #000000;
   --dark-gray: #d9d9d94d; /*연한회색으로 바뀜 */
   --white: #ffffff;
   --light-gray: #909090;
+  --light-green: #afb7b9; /*배경색에 주로 쓰이는 연녹색 */
   --overlay-fill: rgba(217, 217, 217, 0.3); /* #D9D9D9 with 30% opacity */
 }
 

--- a/src/components/footer/FooterStyles.js
+++ b/src/components/footer/FooterStyles.js
@@ -5,8 +5,9 @@ export const FooterContainer = styled.div({
   display: "flex",
   flexDirection: "column",
   width: "100%",
-  backgroundColor: "#afb7b9",
-  backdropFilter: "blur(50px)",
+  backgroundColor: "rgba(217, 217, 217, 0.2)", // bg-[#d9d9d9]/20
+  backdropFilter: "blur(100px)",
+  WebkitBackdropFilter: "blur(100px)",
   paddingLeft: "5vw",
   paddingRight: "5vw",
   "@media (max-width: 768px)": {

--- a/src/pages/Landing/DeptSectionStyle.js
+++ b/src/pages/Landing/DeptSectionStyle.js
@@ -63,7 +63,7 @@ export const DeptTitle = styled.div((props) => ({
 }));
 
 export const DeptSubtitle = styled.span({
-  color: "var(--light-gray)",
+  color: "#757b6f",
   fontSize: "20px",
   fontFamily: "'KoddiUD OnGothic'",
   fontWeight: 400,

--- a/src/pages/Landing/LandingStyle.js
+++ b/src/pages/Landing/LandingStyle.js
@@ -5,7 +5,7 @@ export const MainContainer = styled.div({
   height: "100dvh",
   display: "flex",
   flexDirection: "column",
-  backgroundColor: "black",
+  backgroundColor: "var(--light-green)",
   overflow: "hidden",
   userSelect: "none",
 });

--- a/src/pages/Landing/TitleSection.jsx
+++ b/src/pages/Landing/TitleSection.jsx
@@ -33,15 +33,15 @@ const TitleSection = () => {
       <TitleContent hovered={hoveredLetter}>
         <Row>
           <LetterBlock
-            // onMouseEnter={() => handleHover("g")}
-            // onTouchEnd={() => handleHover("g")}
+          // onMouseEnter={() => handleHover("g")}
+          // onTouchEnd={() => handleHover("g")}
           >
             g
           </LetterBlock>
           <LetterBlock>r</LetterBlock>
           <LetterBlock
-            // onMouseEnter={() => handleHover("a")}
-            // onTouchEnd={() => handleHover("a")}
+          // onMouseEnter={() => handleHover("a")}
+          // onTouchEnd={() => handleHover("a")}
           >
             a
           </LetterBlock>
@@ -125,7 +125,7 @@ const TitleSection = () => {
                   fillRule="evenodd"
                   clipRule="evenodd"
                   d="M22.7989 0.512563C23.4556 -0.170854 24.5205 -0.170854 25.1773 0.512563L36.95 12.7626C37.6068 13.446 37.6068 14.554 36.95 15.2374L25.1773 27.4874C24.5205 28.1709 23.4556 28.1709 22.7989 27.4874C22.1421 26.804 22.1421 25.696 22.7989 25.0126L31.7005 15.75H2.12445C1.1956 15.75 0.442627 14.9665 0.442627 14C0.442627 13.0335 1.1956 12.25 2.12445 12.25H31.7005L22.7989 2.98744C22.1421 2.30402 22.1421 1.19598 22.7989 0.512563Z"
-                  fill="#A348F6"
+                  fill="#4e5a5b"
                 />
               </svg>
               <span className="dept-name">금속공예전공</span>

--- a/src/pages/Landing/TitleSectionStyle.js
+++ b/src/pages/Landing/TitleSectionStyle.js
@@ -18,16 +18,16 @@ export const TitleContent = styled.div((props) => ({
     props.hovered === "g" || props.hovered === "d"
       ? "translateX(248px)" // Right shift for left hover
       : props.hovered === "a" || props.hovered === "u"
-        ? "translateX(-248px)" // Left shift for right hover
-        : "translateX(0)",
+      ? "translateX(-248px)" // Left shift for right hover
+      : "translateX(0)",
   transition: "transform 1.2s ease-in-out",
   "@media (max-width: 768px)": {
     transform:
       props.hovered === "g" || props.hovered === "d"
         ? "translateX(240px)"
         : props.hovered === "a" || props.hovered === "u"
-          ? "translateX(-240px)"
-          : "translateX(0)",
+        ? "translateX(-240px)"
+        : "translateX(0)",
   },
 }));
 
@@ -75,7 +75,7 @@ export const HighlightBlock = styled.div({
 
 export const HighlightBar = styled.div({
   width: "150px",
-  border: "10px solid #A348F6",
+  border: "10px solid var(--purple)",
   "@media (max-width: 768px)": {
     width: "75px",
     border: "5px solid #A348F6",
@@ -85,7 +85,7 @@ export const HighlightBar = styled.div({
 export const PurpleCircleLeft = styled.div({
   width: "537px",
   height: "537px",
-  backgroundColor: "#A348F6",
+  backgroundColor: "var(--purple)",
   borderRadius: "9999px",
   position: "absolute",
   top: "-40%",
@@ -102,7 +102,7 @@ export const PurpleCircleLeft = styled.div({
 export const PurpleCircleRight = styled.div({
   width: "537px",
   height: "537px",
-  backgroundColor: "#A348F6",
+  backgroundColor: "var(--purple)",
   borderRadius: "9999px",
   position: "absolute",
   top: "-40%",
@@ -224,7 +224,7 @@ export const HoverButton = styled(Link)({
       gap: "3px",
     },
     ".dept-name": {
-      color: "#A348F6",
+      color: "var(--purple)",
       fontSize: "30px",
       fontWeight: 700,
       marginLeft: "7px",

--- a/src/pages/PaymentSuccess/PaymentSuccess.jsx
+++ b/src/pages/PaymentSuccess/PaymentSuccess.jsx
@@ -9,14 +9,18 @@ import {
   InfoText,
   InfoWrap,
   PaymentSuccessContainer,
+  MainContainer,
 } from "./PaymentSuccessStyles";
 import { DepartmentHeader } from "../../components/DepartmentHeader/DepartmentHeader";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 function PaymentSuccess() {
   const navigate = useNavigate();
-  const handleNavigate = () => {
-    navigate('/my')
+  const handleNavigateMy = () => {
+    navigate("/my");
+  };
+  const handleNavigateMain = () => {
+    navigate("/");
   };
 
   return (
@@ -25,46 +29,13 @@ function PaymentSuccess() {
         <DepartmentHeader />
       </header>
       <main>
-        <BackgroundCircle></BackgroundCircle>
-        <InfoWrap>
-          <InfoText>결제가 완료되었습니다</InfoText>
-          <InfoBtnWrap>
-            <InfoBtnGoPayWrap onClick={handleNavigate}>
-              <InfoBtnGoPay>구매내역으로 이동</InfoBtnGoPay>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width={window.innerWidth > 768 ? 38 : 18}
-                height="28"
-                viewBox="0 0 38 28"
-                fill="none"
-              >
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M22.7989 0.512563C23.4556 -0.170854 24.5205 -0.170854 25.1773 0.512563L36.95 12.7626C37.6068 13.446 37.6068 14.554 36.95 15.2374L25.1773 27.4874C24.5205 28.1709 23.4556 28.1709 22.7989 27.4874C22.1421 26.804 22.1421 25.696 22.7989 25.0126L31.7005 15.75H2.12445C1.1956 15.75 0.442627 14.9665 0.442627 14C0.442627 13.0335 1.1956 12.25 2.12445 12.25H31.7005L22.7989 2.98744C22.1421 2.30402 22.1421 1.19598 22.7989 0.512563Z"
-                  fill="#A348F6"
-                />
-              </svg>
-            </InfoBtnGoPayWrap>
-            <InfoBtnGoMainWrap>
-              {window.innerWidth > 768 && (
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width={window.innerWidth > 768 ? 38 : 18}
-                  height="28"
-                  viewBox="0 0 38 28"
-                  fill="none"
-                >
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M15.2011 0.512563C14.5444 -0.170854 13.4795 -0.170854 12.8227 0.512563L1.04996 12.7626C0.393177 13.446 0.393177 14.554 1.04996 15.2374L12.8227 27.4874C13.4795 28.1709 14.5444 28.1709 15.2011 27.4874C15.8579 26.804 15.8579 25.696 15.2011 25.0126L6.29946 15.75H35.8756C36.8044 15.75 37.5574 14.9665 37.5574 14C37.5574 13.0335 36.8044 12.25 35.8756 12.25H6.29946L15.2011 2.98744C15.8579 2.30402 15.8579 1.19598 15.2011 0.512563Z"
-                    fill="#A348F6"
-                  />
-                </svg>
-              )}
-              <InfoBtnGoMain>메인페이지로 이동</InfoBtnGoMain>
-              {window.innerWidth <= 768 && (
+        <MainContainer>
+          <BackgroundCircle></BackgroundCircle>
+          <InfoWrap>
+            <InfoText>결제가 완료되었습니다</InfoText>
+            <InfoBtnWrap>
+              <InfoBtnGoPayWrap onClick={handleNavigateMy}>
+                <InfoBtnGoPay>구매내역으로 이동</InfoBtnGoPay>
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width={window.innerWidth > 768 ? 38 : 18}
@@ -76,13 +47,48 @@ function PaymentSuccess() {
                     fillRule="evenodd"
                     clipRule="evenodd"
                     d="M22.7989 0.512563C23.4556 -0.170854 24.5205 -0.170854 25.1773 0.512563L36.95 12.7626C37.6068 13.446 37.6068 14.554 36.95 15.2374L25.1773 27.4874C24.5205 28.1709 23.4556 28.1709 22.7989 27.4874C22.1421 26.804 22.1421 25.696 22.7989 25.0126L31.7005 15.75H2.12445C1.1956 15.75 0.442627 14.9665 0.442627 14C0.442627 13.0335 1.1956 12.25 2.12445 12.25H31.7005L22.7989 2.98744C22.1421 2.30402 22.1421 1.19598 22.7989 0.512563Z"
-                    fill="#A348F6"
+                    fill="#4e5a5b"
                   />
                 </svg>
-              )}
-            </InfoBtnGoMainWrap>
-          </InfoBtnWrap>
-        </InfoWrap>
+              </InfoBtnGoPayWrap>
+              <InfoBtnGoMainWrap onClick={handleNavigateMain}>
+                {window.innerWidth > 768 && (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={window.innerWidth > 768 ? 38 : 18}
+                    height="28"
+                    viewBox="0 0 38 28"
+                    fill="none"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M15.2011 0.512563C14.5444 -0.170854 13.4795 -0.170854 12.8227 0.512563L1.04996 12.7626C0.393177 13.446 0.393177 14.554 1.04996 15.2374L12.8227 27.4874C13.4795 28.1709 14.5444 28.1709 15.2011 27.4874C15.8579 26.804 15.8579 25.696 15.2011 25.0126L6.29946 15.75H35.8756C36.8044 15.75 37.5574 14.9665 37.5574 14C37.5574 13.0335 36.8044 12.25 35.8756 12.25H6.29946L15.2011 2.98744C15.8579 2.30402 15.8579 1.19598 15.2011 0.512563Z"
+                      fill="#4e5a5b"
+                    />
+                  </svg>
+                )}
+                <InfoBtnGoMain>메인페이지로 이동</InfoBtnGoMain>
+                {window.innerWidth <= 768 && (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width={window.innerWidth > 768 ? 38 : 18}
+                    height="28"
+                    viewBox="0 0 38 28"
+                    fill="none"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M22.7989 0.512563C23.4556 -0.170854 24.5205 -0.170854 25.1773 0.512563L36.95 12.7626C37.6068 13.446 37.6068 14.554 36.95 15.2374L25.1773 27.4874C24.5205 28.1709 23.4556 28.1709 22.7989 27.4874C22.1421 26.804 22.1421 25.696 22.7989 25.0126L31.7005 15.75H2.12445C1.1956 15.75 0.442627 14.9665 0.442627 14C0.442627 13.0335 1.1956 12.25 2.12445 12.25H31.7005L22.7989 2.98744C22.1421 2.30402 22.1421 1.19598 22.7989 0.512563Z"
+                      fill="#4e5a5b"
+                    />
+                  </svg>
+                )}
+              </InfoBtnGoMainWrap>
+            </InfoBtnWrap>
+          </InfoWrap>
+        </MainContainer>
       </main>
     </PaymentSuccessContainer>
   );

--- a/src/pages/PaymentSuccess/PaymentSuccessStyles.js
+++ b/src/pages/PaymentSuccess/PaymentSuccessStyles.js
@@ -3,19 +3,19 @@ import styled from "@emotion/styled";
 export const PaymentSuccessContainer = styled.div({
   width: "100vw",
   height: "100vh",
-  background: "#000",
+  background: "var(--light-green)",
   position: "relative",
 });
 
 export const BackgroundCircle = styled.div({
   position: "absolute",
-  top: "15%",
-  left: "23%",
+  top: "27%",
+  left: "22%",
   width: "500px",
   height: "500px",
   flexShrink: 0,
   borderRadius: "500px",
-  background: "#A348F6",
+  background: "var(--purple)",
   "@media (max-width: 768px)": {
     width: "350px",
     height: "350px",
@@ -63,7 +63,7 @@ export const InfoText = styled.div({
 export const InfoBtnWrap = styled.div({
   display: "flex",
   flexDirection: "column",
-  width: `${275 + 275}px`,
+  width: `${290 + 290}px`,
   height: `${69 + 69}px`,
   position: "relative",
   "@media (max-width: 768px)": {
@@ -78,12 +78,12 @@ export const InfoBtnGoMainWrap = styled.div({
   position: "absolute",
   top: "69px",
   left: "0px",
-  width: "275px",
+  width: "290px",
   height: "69px",
   flexShrink: 0,
   borderRadius: "100px",
   background: "rgba(217, 217, 217, 0.30)",
-  backdropFilter: "blur(50px)",
+  backdropFilter: "blur(100px)",
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
@@ -97,13 +97,16 @@ export const InfoBtnGoMainWrap = styled.div({
 });
 
 export const InfoBtnGoMain = styled.div({
-  color: "#FFF",
+  color: "#4e5a5b",
   textAlign: "center",
   fontFamily: "KoddiUD OnGothic",
   fontSize: "24px",
   fontStyle: "normal",
-  fontWeight: "400",
+  fontWeight: "600",
   lineHeight: "100%" /* 24px */,
+  "&:hover": {
+    cursor: "pointer",
+  },
   "@media (max-width: 768px)": {
     fontSize: "12px",
   },
@@ -113,16 +116,19 @@ export const InfoBtnGoPayWrap = styled.div({
   position: "absolute",
   top: "0px",
   right: "0px",
-  width: "275px",
+  width: "290px",
   height: "69px",
   flexShrink: 0,
   borderRadius: "100px",
   background: "rgba(217, 217, 217, 0.30)",
-  backdropFilter: "blur(50px)",
+  backdropFilter: "blur(100px)",
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
   gap: "10px",
+  "&:hover": {
+    cursor: "pointer",
+  },
   "@media (max-width: 768px)": {
     left: "50%",
     width: "150px",
@@ -131,14 +137,23 @@ export const InfoBtnGoPayWrap = styled.div({
 });
 
 export const InfoBtnGoPay = styled.div({
-  color: "#FFF",
+  color: "#4e5a5b",
   textAlign: "center",
   fontFamily: "KoddiUD OnGothic",
   fontSize: "24px",
   fontStyle: "normal",
-  fontWeight: "400",
+  fontWeight: "600",
   lineHeight: "100%" /* 24px */,
   "@media (max-width: 768px)": {
     fontSize: "12px",
   },
+});
+
+export const MainContainer = styled.div({
+  width: "100%",
+  height: "100vh",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
 });


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[d] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/coloruzin -> main

### 변경 사항
메인페이지와 결제 성공 페이지의 색 구성을 변경하였습니다.

### 테스트 결과
![화면 캡처 2024-11-22 175832](https://github.com/user-attachments/assets/84bcfc82-0996-4b33-bbec-cdfb54838bf2)

