### PR TITLE
[Fix] 과별페이지에서 18페이지로 순간이동 문제 수정

### DIFF
--- a/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
+++ b/src/pages/DeptDetail/components/exhibition/DeptDetailExhibitionComponent.jsx
@@ -137,14 +137,14 @@ function ExhibitionGrid({ items, setItems, curDepartmentObj }) {
   const handleNextPage = () => {
     if (currentPage < totalPages) {
       setCurrentPage(currentPage + 1);
-      localStorage.setItem("currentPage", currentPage + 1);
+      localStorage.setItem("currentPage", parseInt(currentPage) + 1);
     }
   };
 
   const handlePreviousPage = () => {
     if (currentPage > 1) {
       setCurrentPage(currentPage - 1);
-      localStorage.setItem("currentPage", currentPage - 1);
+      localStorage.setItem("currentPage", parseInt(currentPage) - 1);
     }
   };
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✅] 버그 수정

### 반영 브랜치
main ← Daeyu_NewQA

### 변경 사항
과별페이지에서 특정 조건에서 다음 페이지 선택 시 18페이지로 순간이동하는 문제를 수정했습니다.
